### PR TITLE
入力動作の強調反映

### DIFF
--- a/src/app/home.js
+++ b/src/app/home.js
@@ -396,8 +396,8 @@ export default function DynamicHome(props) {
 
 
         //　フィルタ適用
-        let filteredPosDiff = deltaPos.clone().multiplyScalar(1/4/18);
-        let filteredQuatDiff = scaleQuaternion(deltaQuat, 1/4/18)
+        let filteredPosDiff = deltaPos.clone().multiplyScalar(1/68); // 基本スケール(1/4) * 速度への変換(大体17msecおき)
+        let filteredQuatDiff = scaleQuaternion(deltaQuat, 1/68)
 
         filteredPosDiff = positionNoizeFilterRef.current.applyFilter(filteredPosDiff)
         filteredQuatDiff = quaternionNoizeFilterRef.current.applyFilter(filteredQuatDiff)
@@ -407,9 +407,8 @@ export default function DynamicHome(props) {
         filteredPosDiff = suppressMovementFilter(filteredPosDiff, filteredQuatDiff)
         filteredQuatDiff = suppressRotationFilter(filteredPosDiff, filteredQuatDiff)
 
-        
-        filteredPosDiff.multiplyScalar(18);
-        filteredQuatDiff = scaleQuaternion(filteredQuatDiff, 18)
+        filteredPosDiff.multiplyScalar(17);
+        filteredQuatDiff = scaleQuaternion(filteredQuatDiff, 17)
 
 
         const filteredDeltaController = new THREE.Matrix4();
@@ -429,26 +428,26 @@ export default function DynamicHome(props) {
 
         // 差分スケーリング
         // reduce controller movement by 0.25 -- 1.00
-        const magnification = controllerMagnificationUsed.current;
-        const posDiff = new THREE.Vector3();
-        const quatDiff = new THREE.Quaternion();
-        const scale = new THREE.Vector3();
-        controllerDiff.decompose(posDiff, quatDiff, scale);
-        const quaterPosDiff = posDiff.clone().multiplyScalar(magnification);
-        // console.debug('quaterPosDiff: ' + quaterPosDiff.x.toFixed(3)
-        // 		  + ', ' + quaterPosDiff.y.toFixed(3)
-        // 		  + ', ' + quaterPosDiff.z.toFixed(3));
-        const quaterQuatDiff = quatDiff.clone(); // .multiplyScalar(0.25);
-        quaterQuatDiff.x *= magnification;
-        quaterQuatDiff.y *= magnification;
-        quaterQuatDiff.z *= magnification;
-        const wAbs = Math.sqrt(1.0 - (quaterQuatDiff.x ** 2
-          + quaterQuatDiff.y ** 2
-          + quaterQuatDiff.z ** 2));
-        quaterQuatDiff.w = quaterQuatDiff.w >= 0 ? wAbs : -wAbs;
-        const scale1 = new THREE.Vector3(1, 1, 1);
-        // const matrixDiff = new THREE.Matrix4();
-        // matrixDiff.compose(quaterPosDiff, quaterQuatDiff, scale1);
+        // const magnification = controllerMagnificationUsed.current;
+        // const posDiff = new THREE.Vector3();
+        // const quatDiff = new THREE.Quaternion();
+        // const scale = new THREE.Vector3();
+        // controllerDiff.decompose(posDiff, quatDiff, scale);
+        // const quaterPosDiff = posDiff.clone().multiplyScalar(magnification);
+        // // console.debug('quaterPosDiff: ' + quaterPosDiff.x.toFixed(3)
+        // // 		  + ', ' + quaterPosDiff.y.toFixed(3)
+        // // 		  + ', ' + quaterPosDiff.z.toFixed(3));
+        // const quaterQuatDiff = quatDiff.clone(); // .multiplyScalar(0.25);
+        // quaterQuatDiff.x *= magnification;
+        // quaterQuatDiff.y *= magnification;
+        // quaterQuatDiff.z *= magnification;
+        // const wAbs = Math.sqrt(1.0 - (quaterQuatDiff.x ** 2
+        //   + quaterQuatDiff.y ** 2
+        //   + quaterQuatDiff.z ** 2));
+        // quaterQuatDiff.w = quaterQuatDiff.w >= 0 ? wAbs : -wAbs;
+        // const scale1 = new THREE.Vector3(1, 1, 1);
+        // // const matrixDiff = new THREE.Matrix4();
+        // // matrixDiff.compose(quaterPosDiff, quaterQuatDiff, scale1);
 
         const matrixDiff = controllerDiff.clone()
         //

--- a/src/app/home.js
+++ b/src/app/home.js
@@ -11,6 +11,7 @@ import { three2worldMatGen, world2threeMatGen } from './constTransformGen';
 import { AppMode } from './appmode.js';
 import StereoVideo from '../lib/stereoWebRTC.js';
 
+import {MovingAveragePositionFilter, MovingAverageQuaternionFilter, emphasizeMovementFilter, emphasizeRotationFilter, suppressMovementFilter, suppressRotationFilter, scaleQuaternion} from '../lib/filters.js'
 
 // const mr = require('../modern_robotics/modern_robotics_core.js');
 // // const RobotKinematics = require('../modern_robotics/modern_robotics_Kinematics.js');
@@ -21,23 +22,23 @@ import StereoVideo from '../lib/stereoWebRTC.js';
 // MQTT Topics
 const MQTT_REQUEST_TOPIC = "mgr/request";
 const MQTT_DEVICE_TOPIC = "dev/" + idtopic;
-const MQTT_CTRL_TOPIC = "control/" ;
-const MQTT_CTRL_TOPIC_ID = "control/"+idtopic ;
+const MQTT_CTRL_TOPIC = "control/";
+const MQTT_CTRL_TOPIC_ID = "control/" + idtopic;
 const MQTT_ROBOT_STATE_TOPIC = "robot/";
 
 console.log("MQTT_DEVICE_TOPIC", MQTT_DEVICE_TOPIC);
 
 // 再レンダリングしなくて値を更新する（かつ set_update で再レンダリングさせられる）
-function useRefState(updateFunc=undefined,initialValue=undefined) {
+function useRefState(updateFunc = undefined, initialValue = undefined) {
   const ref = React.useRef(initialValue);
-  function setValue(arg){
+  function setValue(arg) {
     if (typeof arg === 'function') {
       ref.current = arg(ref.current)
-    }else{
+    } else {
       ref.current = arg
     }
-    if(updateFunc){
-      updateFunc((v)=>v=v+1)
+    if (updateFunc) {
+      updateFunc((v) => v = v + 1)
     }
   }
   return [ref.current, setValue, ref];
@@ -48,8 +49,8 @@ export default function DynamicHome(props) {
   // Generate constant transformation matrices (THREE.Matrix4)
   const [three2worldMat] = React.useState(() => three2worldMatGen());
   const [world2threeMat] = React.useState(() => world2threeMatGen());
-//  console.debug("three2worldMat: ", three2worldMat.elements);
-//  console.debug("world2threeMat: ", world2threeMat.elements);
+  //  console.debug("three2worldMat: ", three2worldMat.elements);
+  //  console.debug("world2threeMat: ", world2threeMat.elements);
 
   const [now, setNow] = React.useState(new Date())
   const [rendered, set_rendered] = React.useState(false)
@@ -61,7 +62,7 @@ export default function DynamicHome(props) {
   const [robot_model, set_robot_model] = React.useState(robotName); // Change this to your robot model
 
   // 
-  const toolLimitList = [{ min: -1, max: 89 }, { min: -1, max: 89 }]; 
+  const toolLimitList = [{ min: -1, max: 89 }, { min: -1, max: 89 }];
   const [toolLimit, setToolLimit] = React.useState(toolLimitList[robotNameList.indexOf(robot_model)] || { min: -1, max: 89 });
 
 
@@ -79,14 +80,14 @@ export default function DynamicHome(props) {
   const [toolCaught, setToolCaught] = React.useState(false); // アームの把持状態
 
   const robotIDRef = React.useRef("none"); // 
-//  console.log("robotIDRef:", robotIDRef.current, "id:", idtopic);
+  //  console.log("robotIDRef:", robotIDRef.current, "id:", idtopic);
   // VR camera pose
   //      set_c_pos_x(0);
-   //     set_c_pos_y(-0.6);
-   //     set_c_pos_z(0.90);
-   //     set_c_deg_x(0);
- //       set_c_deg_y(0);
-   //     set_c_deg_z(0);
+  //     set_c_pos_y(-0.6);
+  //     set_c_pos_z(0.90);
+  //     set_c_deg_x(0);
+  //       set_c_deg_y(0);
+  //     set_c_deg_z(0);
 
 
   const [c_pos_x, set_c_pos_x] = React.useState(0)
@@ -99,10 +100,10 @@ export default function DynamicHome(props) {
   const [updateRobot, setUpdateRobot] = React.useState(0)
   const [dsp_message, set_dsp_message] = React.useState("XXX")
 
-// for useRefState
-  const [update , set_update] = React.useState(0);
-// WebRTCの統計情報を記録
-  const [rtcStats, set_rtcStats, rtcStats_ref ] = useRefState(set_update,[])
+  // for useRefState
+  const [update, set_update] = React.useState(0);
+  // WebRTCの統計情報を記録
+  const [rtcStats, set_rtcStats, rtcStats_ref] = useRefState(set_update, [])
 
 
   const green_color = 'lime';
@@ -127,6 +128,18 @@ export default function DynamicHome(props) {
     controllerStartInv.current = null;
   }, [robot_model]);
 
+  // controller pose
+  const lastControllerPose = React.useRef(new THREE.Matrix4());
+  const cumulativeControllerPose = React.useRef(new THREE.Matrix4());
+  const positionNoizeFilterRef = React.useRef(null);
+  const quaternionNoizeFilterRef = React.useRef(null);
+  if (positionNoizeFilterRef.current === null) {
+    positionNoizeFilterRef.current = new MovingAveragePositionFilter();
+  }
+  if (quaternionNoizeFilterRef.current === null) {
+    quaternionNoizeFilterRef.current = new MovingAverageQuaternionFilter();
+  }
+
   //*** controller mode change functions
   // 20250801 no mode.
   const [controllerModeChange] = React.useState(() => {
@@ -135,15 +148,15 @@ export default function DynamicHome(props) {
     return (incr) => {
       modeNumber += incr;
       if (modeNumber < 0) {
-  modeNumber = controllerMode.length - 1;
+        modeNumber = controllerMode.length - 1;
       } else if (modeNumber >= controllerMode.length) {
-  modeNumber = 0;
+        modeNumber = 0;
       }
-//      console.debug("Controller Mode changed to: ", controllerMode[modeNumber]);
+      //      console.debug("Controller Mode changed to: ", controllerMode[modeNumber]);
       return controllerMode[modeNumber];
     };
   });
-  
+
 
   // *** function that sets the end effector point in the worker thread
   const [toolPointMover] = React.useState(() => {
@@ -156,8 +169,8 @@ export default function DynamicHome(props) {
             type: 'set_end_effector_point',
             endEffectorPoint: toolPoint.toArray()
           });
-//        console.debug("Tool Point moved to: ", toolPoint.x.toFixed(3),
-//          toolPoint.y.toFixed(3), toolPoint.z.toFixed(3));
+        //        console.debug("Tool Point moved to: ", toolPoint.x.toFixed(3),
+        //          toolPoint.y.toFixed(3), toolPoint.z.toFixed(3));
       } else if (delta === null) {
         // reset
         toolPoint.x = 0; toolPoint.y = 0; toolPoint.z = 0.180;
@@ -191,8 +204,8 @@ export default function DynamicHome(props) {
     return mr;
   }
   const theta_body_initial_map = {
-//    'jaka_zu_5': [0, 110, 90, 70, -90, 90].map(x => x * Math.PI / 180),
-//    'jaka_zu_5': [-270, 110, 90, 70, -90, 90].map(x => x * Math.PI / 180),
+    //    'jaka_zu_5': [0, 110, 90, 70, -90, 90].map(x => x * Math.PI / 180),
+    //    'jaka_zu_5': [-270, 110, 90, 70, -90, 90].map(x => x * Math.PI / 180),
     'jaka_zu_5': [-270, 100, 80, 70, -90, 90].map(x => x * Math.PI / 180),
     'agilex_piper': piperMr2urdf([0, -15, 82.6, 0, 70, 0].map(x => x * Math.PI / 180)),
   };
@@ -209,7 +222,7 @@ export default function DynamicHome(props) {
     toolPointMover(null);
     setUpdateRobot(updateRobot + 1);
 
-    
+
   }, [robot_model]);
 
 
@@ -260,7 +273,7 @@ export default function DynamicHome(props) {
               if (props.appmode !== AppMode.viewer) {
                 console.debug("Worker joint message:",
                   event.data.joints.map(x => x.toFixed(3)).join(', '));
-              // Always skip to the latest data
+                // Always skip to the latest data
                 workerLastJoints.current = event.data.joints;
               }
             }
@@ -281,7 +294,7 @@ export default function DynamicHome(props) {
     // **** set status text to "dsp_message" ****
     const intervalId = setInterval(() => {
       const controllerMode = controllerModeChange(0); // Get current controller mode
-      const messageText = ['MODE: '+ controllerMode];
+      const messageText = ['MODE: ' + controllerMode];
       switch (controllerMode) { // controllerMode) {
         case 'Normal':
           messageText
@@ -361,68 +374,112 @@ export default function DynamicHome(props) {
   const controllerMagnificationUsed = React.useRef(controllerMagnification.current);
   // *** a function that runs when the controller pose changes
   React.useEffect(() => {
-    console.log("Controller pose changed:", trigger_on,rendered, vrModeRef.current, endLinkPoseStart.current, baseLinkPoseInv.current);
+    // console.log("Controller pose changed:", trigger_on,rendered, vrModeRef.current, endLinkPoseStart.current, baseLinkPoseInv.current);
     // VR input period
     if (endLinkPoseStart.current !== null &&
       baseLinkPoseInv.current !== null &&
       rendered && vrModeRef.current && trigger_on) {
 
-      console.log("Controll started with trigger_on:", trigger_on);  
+      // console.log("Controll started with trigger_on:", trigger_on);  
       // base_B^{-1}: start^-1: controllerStartInv.current
       // base_E: goal: controllerCurrentWorld
       // base_S: begin: endLinkPoseStart.current
       // base_S': 原点はB, 向きはS
       // base_G: end: to be calculated
       const controllerCurrentWorld = three2worldMat.clone().multiply(controller_object);
-      const controllerDiff = controllerStartInv.current.clone().multiply(controllerCurrentWorld);
-      const controllerTend = controllerStartInv.current.clone().multiply(endLinkPoseStart.current);
-      controllerTend.extractRotation(controllerTend);
-      const endTcontroller = controllerTend.clone().transpose();
-      //
-      // reduce controller movement by 0.25 -- 1.00
-      const magnification = controllerMagnificationUsed.current;
-      const posDiff = new THREE.Vector3();
-      const quatDiff = new THREE.Quaternion();
-      const scale = new THREE.Vector3();
-      controllerDiff.decompose(posDiff, quatDiff, scale);
-      const quaterPosDiff = posDiff.clone().multiplyScalar(magnification);
-      // console.debug('quaterPosDiff: ' + quaterPosDiff.x.toFixed(3)
-      // 		  + ', ' + quaterPosDiff.y.toFixed(3)
-      // 		  + ', ' + quaterPosDiff.z.toFixed(3));
-      const quaterQuatDiff = quatDiff.clone(); // .multiplyScalar(0.25);
-      quaterQuatDiff.x *= magnification;
-      quaterQuatDiff.y *= magnification;
-      quaterQuatDiff.z *= magnification;
-      const wAbs = Math.sqrt(1.0 - (quaterQuatDiff.x ** 2
-        + quaterQuatDiff.y ** 2
-        + quaterQuatDiff.z ** 2));
-      quaterQuatDiff.w = quaterQuatDiff.w >= 0 ? wAbs : -wAbs;
-      const scale1 = new THREE.Vector3(1, 1, 1);
-      const matrixDiff = new THREE.Matrix4();
-      matrixDiff.compose(quaterPosDiff, quaterQuatDiff, scale1);
-      //
-      //
-      const newEndLinkPose = endLinkPoseStart.current.clone()
-        .multiply(endTcontroller).multiply(matrixDiff)
-        .multiply(controllerTend);
-      console.debug("matrixDiff: ", matrixDiff.elements[12].toFixed(3),
-        matrixDiff.elements[13].toFixed(3),
-        matrixDiff.elements[14].toFixed(3));
-      console.debug("newEndLinkPose: ", newEndLinkPose.elements[12].toFixed(3),
-        newEndLinkPose.elements[13].toFixed(3),
-        newEndLinkPose.elements[14].toFixed(3));
-      // **** send to worker thread ****
-      workerRef.current.postMessage({
-        type: 'destination',
-        endLinkPose: newEndLinkPose.elements
-      });
-      // KinematicsControl(newEndLinkPose);
-      // if (workerLastJoints.current) {
-      // 	setThetaBody(workerLastJoints.current);
-      // }
+      if (!lastControllerPose.current.equals(new THREE.Matrix4())) {
+        const deltaControllerPose = lastControllerPose.current.clone().invert().multiply(controllerCurrentWorld);
+        const deltaPos = new THREE.Vector3();
+        const deltaQuat = new THREE.Quaternion();
+        const deltaScale = new THREE.Vector3();
+        deltaControllerPose.decompose(deltaPos, deltaQuat, deltaScale);
+
+
+        //　フィルタ適用
+        let filteredPosDiff = deltaPos.clone().multiplyScalar(1/4/18);
+        let filteredQuatDiff = scaleQuaternion(deltaQuat, 1/4/18)
+
+        filteredPosDiff = positionNoizeFilterRef.current.applyFilter(filteredPosDiff)
+        filteredQuatDiff = quaternionNoizeFilterRef.current.applyFilter(filteredQuatDiff)
+
+        filteredPosDiff = emphasizeMovementFilter(filteredPosDiff)
+        filteredQuatDiff = emphasizeRotationFilter(filteredQuatDiff)
+        filteredPosDiff = suppressMovementFilter(filteredPosDiff, filteredQuatDiff)
+        filteredQuatDiff = suppressRotationFilter(filteredPosDiff, filteredQuatDiff)
+
+        
+        filteredPosDiff.multiplyScalar(18);
+        filteredQuatDiff = scaleQuaternion(filteredQuatDiff, 18)
+
+
+        const filteredDeltaController = new THREE.Matrix4();
+        filteredDeltaController.compose(filteredPosDiff, filteredQuatDiff, deltaScale);
+
+        const filteredControllerCurrentWorld = cumulativeControllerPose.current.clone().multiply(filteredDeltaController);
+        const controllerDiff = controllerStartInv.current.clone().multiply(filteredControllerCurrentWorld);
+
+        cumulativeControllerPose.current.copy(filteredControllerCurrentWorld)
+        lastControllerPose.current.copy(controllerCurrentWorld);
+
+        // 以下の処理はそのまま
+        const controllerTend = controllerStartInv.current.clone().multiply(endLinkPoseStart.current); // トリガー押下〜EEの変換
+        controllerTend.extractRotation(controllerTend);
+        const endTcontroller = controllerTend.clone().transpose();
+        //
+
+        // 差分スケーリング
+        // reduce controller movement by 0.25 -- 1.00
+        const magnification = controllerMagnificationUsed.current;
+        const posDiff = new THREE.Vector3();
+        const quatDiff = new THREE.Quaternion();
+        const scale = new THREE.Vector3();
+        controllerDiff.decompose(posDiff, quatDiff, scale);
+        const quaterPosDiff = posDiff.clone().multiplyScalar(magnification);
+        // console.debug('quaterPosDiff: ' + quaterPosDiff.x.toFixed(3)
+        // 		  + ', ' + quaterPosDiff.y.toFixed(3)
+        // 		  + ', ' + quaterPosDiff.z.toFixed(3));
+        const quaterQuatDiff = quatDiff.clone(); // .multiplyScalar(0.25);
+        quaterQuatDiff.x *= magnification;
+        quaterQuatDiff.y *= magnification;
+        quaterQuatDiff.z *= magnification;
+        const wAbs = Math.sqrt(1.0 - (quaterQuatDiff.x ** 2
+          + quaterQuatDiff.y ** 2
+          + quaterQuatDiff.z ** 2));
+        quaterQuatDiff.w = quaterQuatDiff.w >= 0 ? wAbs : -wAbs;
+        const scale1 = new THREE.Vector3(1, 1, 1);
+        // const matrixDiff = new THREE.Matrix4();
+        // matrixDiff.compose(quaterPosDiff, quaterQuatDiff, scale1);
+
+        const matrixDiff = controllerDiff.clone()
+        //
+        //
+        const newEndLinkPose = endLinkPoseStart.current.clone()
+          .multiply(endTcontroller).multiply(matrixDiff)
+          .multiply(controllerTend);
+        console.debug("matrixDiff: ", matrixDiff.elements[12].toFixed(3),
+          matrixDiff.elements[13].toFixed(3),
+          matrixDiff.elements[14].toFixed(3));
+        console.debug("newEndLinkPose: ", newEndLinkPose.elements[12].toFixed(3),
+          newEndLinkPose.elements[13].toFixed(3),
+          newEndLinkPose.elements[14].toFixed(3));
+        // **** send to worker thread ****
+        workerRef.current.postMessage({
+          type: 'destination',
+          endLinkPose: newEndLinkPose.elements
+        });
+        // KinematicsControl(newEndLinkPose);
+        // if (workerLastJoints.current) {
+        // 	setThetaBody(workerLastJoints.current);
+        // }
+      }
+      else {
+        console.log("init")
+        cumulativeControllerPose.current.copy(controllerCurrentWorld)
+        lastControllerPose.current.copy(controllerCurrentWorld);
+      }
     }
     // ** update the controller and end link pose at the trigger_on change
-//    console.log("controllerUpdate: ", controllerUpdate);
+    //    console.log("controllerUpdate: ", controllerUpdate);
     let updateStartPose = false;
     if (baseLinkPoseInv.current !== null) {
       if (!trigger_on) {
@@ -437,7 +494,7 @@ export default function DynamicHome(props) {
       }
       if (updateStartPose || endLinkPoseStart.current === null) {
         // do update start pose of end link
-        console.log("update start pose of end link",workerLastPose.current);
+        console.log("update start pose of end link", workerLastPose.current);
         if (workerLastPose.current) {
           endLinkPoseStart.current = endLinkPose.current.clone();
           // endLinkPoseStart.current = three2worldMat.clone()
@@ -456,6 +513,10 @@ export default function DynamicHome(props) {
           controllerStartInv.current.elements[12].toFixed(3),
           controllerStartInv.current.elements[13].toFixed(3),
           controllerStartInv.current.elements[14].toFixed(3));
+      }
+      if (updateStartPose || cumulativeControllerPose.current === null) {
+        cumulativeControllerPose.current.identity(); // 単位行列で初期化
+        lastControllerPose.current.identity(); // 前回姿勢もリセット
       }
     }
     controllerMagnificationPrev.current = controllerMagnification.current;
@@ -621,8 +682,8 @@ export default function DynamicHome(props) {
   useMqtt({
     props,
     requestRobot,
-	  toolCaught,
-	  setToolCaught,
+    toolCaught,
+    setToolCaught,
     setThetaBody: setThetaBody,
     setThetaTool: setThetaTool,
     robotIDRef,
@@ -636,7 +697,7 @@ export default function DynamicHome(props) {
 
   // Robot State Update Props
   const robotProps = React.useMemo(() => ({
-    updateRobot, robotNameList, robotName, theta_body, theta_tool , base_position,base_rotation,
+    updateRobot, robotNameList, robotName, theta_body, theta_tool, base_position, base_rotation,
     toolCaught
   }), [updateRobot, robotNameList, robotName, theta_body, theta_tool]);
 

--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -1,0 +1,203 @@
+export class MovingAverageQuaternionFilter {
+    constructor(
+        windowSize = 5,
+        rotateThreshold = 0.0001 / 35
+    ) {
+        this.windowSize = windowSize;
+        this.rotateThreshold = rotateThreshold;
+        this.quaternionBuffer = [];
+        this.smoothedQuaternion = new THREE.Quaternion(0, 0, 0, 1);
+    }
+
+    applyFilter(quaternion) {
+        return this.smoothQuaternion(quaternion);
+    }
+
+    smoothQuaternion(quaternion) {
+        // THREE.Quaternionとしてバッファに追加
+        this.quaternionBuffer.push(quaternion.clone());
+        if (this.quaternionBuffer.length > this.windowSize) {
+            this.quaternionBuffer.shift();
+        }
+
+        if (this.quaternionBuffer.length === 1) {
+            this.smoothedQuaternion = this.quaternionBuffer[0].clone();
+        } else {
+            this.smoothedQuaternion = this.slerpAverage(this.quaternionBuffer);
+        }
+
+        // 回転角度の閾値チェック
+        const identity = new THREE.Quaternion(0, 0, 0, 1);
+        const rotationAngle = this.smoothedQuaternion.angleTo(identity);
+
+        if (Math.abs(rotationAngle) < this.rotateThreshold) {
+            return new THREE.Quaternion(0, 0, 0, 1); // 単位クォータニオン
+        }
+
+        return this.smoothedQuaternion.clone();
+    }
+
+    slerpAverage(quaternions) {
+        if (quaternions.length === 0) {
+            return new THREE.Quaternion(0, 0, 0, 1);
+        }
+        if (quaternions.length === 1) {
+            return quaternions[0].clone();
+        }
+
+        // 最初のクォータニオンから開始
+        let result = quaternions[0].clone();
+
+        // 段階的にSLERPで平均化
+        for (let i = 1; i < quaternions.length; i++) {
+            const t = 1.0 / (i + 1);
+            result.slerp(quaternions[i], t);
+        }
+
+        return result.normalize();
+    }
+
+    reset() {
+        this.quaternionBuffer = [];
+        this.smoothedQuaternion = new THREE.Quaternion(0, 0, 0, 1);
+    }
+}
+
+export class MovingAveragePositionFilter {
+    constructor(
+        windowSize = 5,
+        moveThreshold = 0.00001 / 35
+    ) {
+        this.windowSize = windowSize;
+        this.moveThreshold = moveThreshold;
+
+        this.positionBuffer = [];
+        this.smoothedPosition = new THREE.Vector3(0, 0, 0);
+    }
+
+    applyFilter(position) {
+        return this.smoothPosition(position);
+    }
+
+    smoothPosition(position) {
+        // Vector3の場合はclone、プレーンオブジェクトの場合はコピー
+        if (position.isVector3) {
+            this.positionBuffer.push(position.clone());
+        } else {
+            this.positionBuffer.push(new THREE.Vector3(position.x, position.y, position.z));
+        }
+
+        if (this.positionBuffer.length > this.windowSize) {
+            this.positionBuffer.shift();
+        }
+
+        // Vector3での平均計算
+        const sum = this.positionBuffer.reduce((acc, val) => {
+            acc.add(val);
+            return acc;
+        }, new THREE.Vector3(0, 0, 0));
+
+        this.smoothedPosition = sum.divideScalar(this.positionBuffer.length);
+
+        // 閾値以下の微小な動きは0に設定
+        this.smoothedPosition.x = Math.abs(this.smoothedPosition.x) < this.moveThreshold ? 0 : this.smoothedPosition.x;
+        this.smoothedPosition.y = Math.abs(this.smoothedPosition.y) < this.moveThreshold ? 0 : this.smoothedPosition.y;
+        this.smoothedPosition.z = Math.abs(this.smoothedPosition.z) < this.moveThreshold ? 0 : this.smoothedPosition.z;
+
+        return this.smoothedPosition.clone();
+    }
+
+    reset() {
+        this.positionBuffer = [];
+        this.smoothedPosition = new THREE.Vector3(0, 0, 0);
+    }
+}
+
+export const emphasizeMovementFilter = (position, params = {
+    threshold: 0.001 / 35,
+    accelerationExponent: 2.3,
+    accelerationFactor: 180000 * Math.pow(35, 2.3),
+    maxAcceleration: 3,
+}) => {
+    const movementDistance = position.length(); // Vector3のlength()メソッド使用
+    const emphasizedScale = calculateEmphasizeScale(movementDistance, params);
+    return position.clone().multiplyScalar(emphasizedScale); // Vector3のメソッド使用
+}
+
+export const emphasizeRotationFilter = (quaternion, params = {
+    threshold: 0.005 / 35,
+    accelerationExponent: 2.3,
+    accelerationFactor: 1500 * Math.pow(35, 2.3),
+    maxAcceleration: 3,
+}) => {
+    const { radian: rotationRadian } = quaternionToAngle(quaternion);
+    const emphasizedScale = calculateEmphasizeScale(rotationRadian, params);
+    return scaleQuaternion(quaternion, emphasizedScale);
+}
+
+export const suppressMovementFilter = (position, quaternion, params = {
+    threshold: 0.01 / 35,
+    suppressionExponent: 1.5,
+    suppressionFactor: 500 * Math.pow(35, 1.5),
+    minSuppression: 0.001,
+}) => {
+    const { radian: rotationRadian } = quaternionToAngle(quaternion);
+    const suppressedScale = calculateSuppressScale(rotationRadian, params);
+    return position.clone().multiplyScalar(suppressedScale); // Vector3のメソッド使用
+}
+
+export const suppressRotationFilter = (position, quaternion, params = {
+    threshold: 0.01 / 35,
+    suppressionExponent: 1.5,
+    suppressionFactor: 10 * Math.pow(50, 1.5),
+    minSuppression: 0.0001,
+}) => {
+    const movementDistance = position.length(); // Vector3のlength()メソッド使用
+    const suppressedScale = calculateSuppressScale(movementDistance, params);
+    return scaleQuaternion(quaternion, suppressedScale);
+}
+
+const calculateEmphasizeScale = (motionDifference, params) => {
+    if (motionDifference < params.threshold) return 1.0;
+    const normalizedInput = motionDifference - params.threshold;
+    const curvedInput = Math.pow(normalizedInput, params.accelerationExponent);
+    const acceleration = 1.0 + curvedInput * params.accelerationFactor;
+
+    return Math.min(acceleration, params.maxAcceleration);
+}
+
+const calculateSuppressScale = (motionDifference, params) => {
+    if (motionDifference < params.threshold) return 1.0;
+    const normalizedInput = Math.min((motionDifference - params.threshold), 1.0);
+    const curvedInput = Math.pow(normalizedInput, params.suppressionExponent);
+
+    return Math.max(1.0 - (curvedInput * params.suppressionFactor), params.minSuppression);
+}
+
+export const scaleQuaternion = (quaternion, factor) => {
+    const identity = new THREE.Quaternion()
+    const scaledQuaternion = new THREE.Quaternion()
+    scaledQuaternion.slerpQuaternions(identity, quaternion, factor)
+    return scaledQuaternion
+}
+
+const quaternionToAngle = (q) => {
+    const radian = 2 * Math.acos(round(q.w))
+    if (radian === 0) {
+        return { radian, axis: new THREE.Vector3(0, 0, 0) }
+    }
+    const sinHalfAngle = Math.sqrt(1 - q.w * q.w)
+    if (sinHalfAngle > 0) {
+        const axisX = (q.x / sinHalfAngle)
+        const axisY = (q.y / sinHalfAngle)
+        const axisZ = (q.z / sinHalfAngle)
+        return { angle, radian, axis: new THREE.Vector3(axisX, axisY, axisZ) }
+    } else {
+        return { angle, radian, axis: new THREE.Vector3(0, 0, 0) }
+    }
+}
+
+const round = (x, d = 5) => {
+    const v = 10 ** (d | 0)
+    return Math.round(x * v) / v
+}

--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -113,46 +113,57 @@ export class MovingAveragePositionFilter {
     }
 }
 
-export const emphasizeMovementFilter = (position, params = {
+
+const MOVEMENT_EMPHASIZE_DEFAULTS = {
     threshold: 0.001 / 35,
     accelerationExponent: 2.3,
     accelerationFactor: 180000 * Math.pow(35, 2.3),
     maxAcceleration: 3,
-}) => {
-    const movementDistance = position.length(); // Vector3のlength()メソッド使用
-    const emphasizedScale = calculateEmphasizeScale(movementDistance, params);
-    return position.clone().multiplyScalar(emphasizedScale); // Vector3のメソッド使用
-}
+};
 
-export const emphasizeRotationFilter = (quaternion, params = {
+const ROTATION_EMPHASIZE_DEFAULTS = {
     threshold: 0.005 / 35,
     accelerationExponent: 2.3,
     accelerationFactor: 1500 * Math.pow(35, 2.3),
     maxAcceleration: 3,
-}) => {
-    const { radian: rotationRadian } = quaternionToAngle(quaternion);
+};
+
+const MOVEMENT_SUPPRESS_DEFAULTS = {
+    threshold: 0.05 / 35,
+    suppressionExponent: 1.5,
+    suppressionFactor: 500 * Math.pow(35, 1.5),
+    minSuppression: 0.001,
+};
+
+const ROTATION_SUPPRESS_DEFAULTS = {
+    threshold: 0.01 / 35,
+    suppressionExponent: 1.5,
+    suppressionFactor: 10 * Math.pow(35, 1.5),
+    minSuppression: 0.0001,
+};
+
+export const emphasizeMovementFilter = (position, params = MOVEMENT_EMPHASIZE_DEFAULTS) => {
+    const movementDistance = position.length();
+    const emphasizedScale = calculateEmphasizeScale(movementDistance, params);
+    return position.clone().multiplyScalar(emphasizedScale);
+}
+
+export const emphasizeRotationFilter = (quaternion, params = ROTATION_EMPHASIZE_DEFAULTS) => {
+    const q = quaternion.clone().normalize();
+    const rotationRadian = 2 * Math.acos(Math.abs(q.w));
     const emphasizedScale = calculateEmphasizeScale(rotationRadian, params);
     return scaleQuaternion(quaternion, emphasizedScale);
 }
 
-export const suppressMovementFilter = (position, quaternion, params = {
-    threshold: 0.01 / 35,
-    suppressionExponent: 1.5,
-    suppressionFactor: 500 * Math.pow(35, 1.5),
-    minSuppression: 0.001,
-}) => {
-    const { radian: rotationRadian } = quaternionToAngle(quaternion);
+export const suppressMovementFilter = (position, quaternion, params = MOVEMENT_SUPPRESS_DEFAULTS) => {
+    const q = quaternion.clone().normalize();
+    const rotationRadian = 2 * Math.acos(Math.abs(q.w));
     const suppressedScale = calculateSuppressScale(rotationRadian, params);
-    return position.clone().multiplyScalar(suppressedScale); // Vector3のメソッド使用
+    return position.clone().multiplyScalar(suppressedScale);
 }
 
-export const suppressRotationFilter = (position, quaternion, params = {
-    threshold: 0.01 / 35,
-    suppressionExponent: 1.5,
-    suppressionFactor: 10 * Math.pow(50, 1.5),
-    minSuppression: 0.0001,
-}) => {
-    const movementDistance = position.length(); // Vector3のlength()メソッド使用
+export const suppressRotationFilter = (position, quaternion, params = ROTATION_SUPPRESS_DEFAULTS) => {
+    const movementDistance = position.length();
     const suppressedScale = calculateSuppressScale(movementDistance, params);
     return scaleQuaternion(quaternion, suppressedScale);
 }
@@ -162,7 +173,7 @@ const calculateEmphasizeScale = (motionDifference, params) => {
     const normalizedInput = motionDifference - params.threshold;
     const curvedInput = Math.pow(normalizedInput, params.accelerationExponent);
     const acceleration = 1.0 + curvedInput * params.accelerationFactor;
-
+    
     return Math.min(acceleration, params.maxAcceleration);
 }
 
@@ -170,34 +181,13 @@ const calculateSuppressScale = (motionDifference, params) => {
     if (motionDifference < params.threshold) return 1.0;
     const normalizedInput = Math.min((motionDifference - params.threshold), 1.0);
     const curvedInput = Math.pow(normalizedInput, params.suppressionExponent);
-
+    
     return Math.max(1.0 - (curvedInput * params.suppressionFactor), params.minSuppression);
 }
 
 export const scaleQuaternion = (quaternion, factor) => {
-    const identity = new THREE.Quaternion()
-    const scaledQuaternion = new THREE.Quaternion()
-    scaledQuaternion.slerpQuaternions(identity, quaternion, factor)
-    return scaledQuaternion
-}
-
-const quaternionToAngle = (q) => {
-    const radian = 2 * Math.acos(round(q.w))
-    if (radian === 0) {
-        return { radian, axis: new THREE.Vector3(0, 0, 0) }
-    }
-    const sinHalfAngle = Math.sqrt(1 - q.w * q.w)
-    if (sinHalfAngle > 0) {
-        const axisX = (q.x / sinHalfAngle)
-        const axisY = (q.y / sinHalfAngle)
-        const axisZ = (q.z / sinHalfAngle)
-        return { angle, radian, axis: new THREE.Vector3(axisX, axisY, axisZ) }
-    } else {
-        return { angle, radian, axis: new THREE.Vector3(0, 0, 0) }
-    }
-}
-
-const round = (x, d = 5) => {
-    const v = 10 ** (d | 0)
-    return Math.round(x * v) / v
+    const identity = new THREE.Quaternion();
+    const scaledQuaternion = new THREE.Quaternion();
+    scaledQuaternion.slerpQuaternions(identity, quaternion, factor);
+    return scaledQuaternion;
 }


### PR DESCRIPTION
- コントローラ情報取得でposition, quaternionを独立して更新していたが，まとめて更新に変更
- Targetの計算方法を変更
    1. 現在と前回取得時のコントローラの動作差分を計算
    2. 差分にフィルターを適用
    3. 前回のフィルタ後のコントローラ姿勢に差分を加算．次回のために保持する
    4. コントローラ姿勢と前回のフィルター後の世界座標系に対するコントローラ姿勢を保存
    5. ⅲ.を現在の世界座標系に対するコントローラ情報入力として扱い，以下はこれまで同様に処理
